### PR TITLE
feat: Add lodash-es dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,20 @@
 {
   "name": "@paddls/ts-serializer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@paddls/ts-serializer",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "lodash.intersection": "^4.4.0",
-        "lodash.set": "^4.3.2",
+        "lodash-es": "^4.17.21",
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
         "@types/jest": "^24.0.23",
+        "@types/lodash-es": "^4.17.12",
         "@types/node": "^12.12.17",
         "coveralls": "^3.1.1",
         "jest": "^29.7.0",
@@ -1121,6 +1119,21 @@
         "jest-diff": "^24.3.0"
       }
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
+      "dev": true
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "12.20.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
@@ -1397,12 +1410,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1951,9 +1964,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3314,31 +3327,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
-    "node_modules/lodash.intersection": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
-      "integrity": "sha512-N+L0cCfnqMv6mxXtSPeKt+IavbOBBSiAEkKyLasZ8BVcP9YXQgxLO12oPR8OyURwKV8l5vJKiE1M8aS70heuMg=="
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/log-driver": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -24,14 +24,12 @@
     "typescript": ">=3.4.3"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.get": "^4.4.2",
-    "lodash.intersection": "^4.4.0",
-    "lodash.set": "^4.3.2",
+    "lodash-es": "^4.17.21",
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^12.12.17",
     "coveralls": "^3.1.1",
     "jest": "^29.7.0",

--- a/src/e2e/serializer.spec-e2e.ts
+++ b/src/e2e/serializer.spec-e2e.ts
@@ -9,7 +9,7 @@ import {Driver} from './driver.model';
 import {Address} from './address.model';
 import {Car} from './car.model';
 import {Truck} from './truck.model';
-import cloneDeep from 'lodash.clonedeep';
+import {cloneDeep} from 'lodash-es';
 
 describe('Serializer E2E', () => {
   let vehicleData: any;

--- a/src/normalizer/denormalizer.spec.ts
+++ b/src/normalizer/denormalizer.spec.ts
@@ -5,7 +5,7 @@ import {JsonProperty} from '../decorator/json-property.decorator';
 import {DateConverter} from '../converter/date.converter';
 import {JsonTypeSupports} from '../decorator/json-type-supports.decorator';
 import {SerializerOptions} from '../serializer-options';
-import cloneDeep from 'lodash.clonedeep';
+import {cloneDeep} from 'lodash-es';
 
 class EmptyJsonProperty {
   public name: string = 'myEmptyJsonPropertyObject';

--- a/src/normalizer/denormalizer.ts
+++ b/src/normalizer/denormalizer.ts
@@ -4,8 +4,8 @@ import {SerializeType} from '../common';
 import {IDeserializer} from '../ideserializer';
 import {JSON_TYPE_SUPPORTS_METADATA_KEY} from '../decorator/json-type-supports.decorator';
 import {normalizeSerializerOptions, SerializerOptions} from '../serializer-options';
-import get from 'lodash.get';
-import intersection from 'lodash.intersection';
+import {get} from 'lodash-es';
+import {intersection} from 'lodash-es';
 
 export class Denormalizer implements IDeserializer {
 

--- a/src/normalizer/normalizer.configuration.spec.ts
+++ b/src/normalizer/normalizer.configuration.spec.ts
@@ -1,5 +1,5 @@
 import {DEFAULT_NORMALIZER_CONFIGURATION, NormalizerConfiguration} from './normalizer.configuration';
-import cloneDeep from 'lodash.clonedeep';
+import {cloneDeep} from 'lodash-es';
 
 describe('NormalizerConfiguration', () => {
 

--- a/src/normalizer/normalizer.spec.ts
+++ b/src/normalizer/normalizer.spec.ts
@@ -4,7 +4,7 @@ import {DEFAULT_NORMALIZER_CONFIGURATION, NormalizerConfiguration} from './norma
 import {JsonProperty} from '../decorator/json-property.decorator';
 import {DateConverter} from '../converter/date.converter';
 import {SerializerOptions} from '../serializer-options';
-import cloneDeep from 'lodash.clonedeep';
+import {cloneDeep} from 'lodash-es';
 
 class EmptyJsonProperty {
   public name: string = 'myEmptyJsonPropertyObject';

--- a/src/normalizer/normalizer.ts
+++ b/src/normalizer/normalizer.ts
@@ -2,8 +2,8 @@ import {JSON_PROPERTY_METADATA_KEY, JsonPropertyContextConfiguration} from '../d
 import {DEFAULT_NORMALIZER_CONFIGURATION, NormalizerConfiguration} from './normalizer.configuration';
 import {ISerializer} from '../iserializer';
 import {normalizeSerializerOptions, SerializerOptions} from '../serializer-options';
-import set from 'lodash.set';
-import intersection from 'lodash.intersection';
+import {set} from 'lodash-es';
+import {intersection} from 'lodash-es';
 
 export class Normalizer implements ISerializer {
 

--- a/src/serializer-options.ts
+++ b/src/serializer-options.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash.clonedeep';
+import {cloneDeep} from 'lodash-es';
 
 export interface SerializerOptions {
 


### PR DESCRIPTION
The idea is to no longer have dependencies with a high vulnerability, https://github.com/advisories/GHSA-p6mc-m468-83gw